### PR TITLE
12286 - Priorização do preço PIX em SEO e na PDP

### DIFF
--- a/components/product/ProductDetails.tsx
+++ b/components/product/ProductDetails.tsx
@@ -101,7 +101,7 @@ function ProductInfo(
                 <div class="bg-primary rounded-[16px] py-1 px-4 pointer-events-none relative text-left top-[unset] w-fit z-1">
                   <div class="flex justify-center items-center flex-col text-white h-full">
                     <p class="text-sm font-normal leading-4 whitespace-nowrap font-quicksand">
-                      - {discount}%
+                      -{discount}%
                     </p>
                   </div>
                 </div>
@@ -109,15 +109,15 @@ function ProductInfo(
             )}
             <div class="py-[1.375rem] max-lg:pb-0">
               <div class="flex flex-col font-quicksand">
-                {discount && (
-                  <del class="text-[#828282] text-[14px] leading-[1.125rem] line-through">
-                    {formatPrice(listPrice, offers!.priceCurrency!)}
-                  </del>
-                )}
                 {priceWithPixDiscount && (
                   <p class="text-secondary text-[26px] font-extrabold">
                     {formatPrice(priceWithPixDiscount, offers!.priceCurrency!)}
                   </p>
+                )}
+                {discount && (
+                  <del class="text-[#828282] text-[14px] leading-[1.125rem] line-through -order-1">
+                    {formatPrice(listPrice, offers!.priceCurrency!)}
+                  </del>
                 )}
                 <p class="text-secondary text-sm font-semibold leading-5 flex-col items-start font-quicksand mb-3">
                   à vista no Pix ou em 1x no cartão

--- a/sections/Seo/CustomProductSEO.tsx
+++ b/sections/Seo/CustomProductSEO.tsx
@@ -32,6 +32,7 @@ import {
 } from "$store/utils/seo/metaTags.ts";
 import { getOfferPrice } from "$store/utils/seo/offerPrice.ts";
 import { MetaTags } from "$store/components/seo/MetaTags.tsx";
+import { calculatePixPromotion } from "../../utils/seo/pixPromotion.ts";
 
 interface Props {
   page: ProductDetailsPage | null;
@@ -70,11 +71,6 @@ export default function CustomProductSEO(
   if (!page?.product) return <div></div>;
   const product = page.product;
 
-  // Esta função calcula o preço com o desconto do pix
-  // Veja em `/utils/seo/pixPromotion.ts`
-  // const { promotionalPrice } = calculatePixPromotion(
-  //   product.offers?.offers || [],
-  // );
   const fullProductName = product.isVariantOf?.name || product.name;
   const { category } = extractProductCategories(product);
   const specifications = extractProductSpecifications(product);
@@ -85,9 +81,8 @@ export default function CustomProductSEO(
     product.offers?.offers?.[0],
     "ListPrice",
   );
-  const promotionalPrice = getOfferPrice(
-    product.offers?.offers?.[0],
-    "SalePrice",
+  const { promotionalPrice } = calculatePixPromotion(
+    product.offers?.offers,
   );
   const priceCurrency = product.offers?.priceCurrency || "BRL";
   const availability = product.offers?.offers?.[0]?.availability ||
@@ -96,7 +91,6 @@ export default function CustomProductSEO(
   const priceValidUntil = product.offers?.offers?.[0]?.priceValidUntil;
   const inventoryLevel = product.offers?.offers?.[0]?.inventoryLevel?.value;
 
-  const price = originalPrice;
   const heightStr = getSpecValue("altura");
   const heightValue = parseHeightValue(heightStr);
   const widthStr = getSpecValue("largura");
@@ -173,7 +167,7 @@ export default function CustomProductSEO(
         imageUrl={imageUrl}
         keywords={keywords}
         availability={availability}
-        price={price}
+        price={promotionalPrice}
         priceCurrency={priceCurrency}
         favicon={favicon}
       />

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -4569,6 +4569,9 @@ details.collapse summary::-webkit-details-marker {
 .z-\[9\] {
   z-index: 9;
 }
+.-order-1 {
+  order: -1;
+}
 .order-1 {
   order: 1;
 }

--- a/utils/seo/pixPromotion.ts
+++ b/utils/seo/pixPromotion.ts
@@ -1,20 +1,24 @@
 import { Offer } from "apps/commerce/types.ts";
+import { getOfferPrice } from "./offerPrice.ts";
 
 export interface PixPromotionResult {
-  promotionalPrice: number | null;
-  discountPercentage: number;
+  promotionalPrice: number;
 }
 
-export function calculatePixPromotion(offers: Offer[]): PixPromotionResult {
-  const pixPromotion = offers?.[0]?.teasers?.find(
+export function calculatePixPromotion(offers?: Offer[]): PixPromotionResult {
+  if (!offers || offers.length === 0) {
+    return { promotionalPrice: 0 };
+  }
+
+  const offer = offers[0];
+  let promotionalPrice = getOfferPrice(offer, "SalePrice");
+
+  const pixPromotion = offer?.teasers?.find(
     (teaser) =>
       teaser.conditions?.parameters?.some(
         (param) => param.name === "PaymentMethodId" && param.value === "712",
       ),
   );
-
-  let promotionalPrice = null;
-  let discountPercentage = 0;
 
   if (pixPromotion) {
     const discountParam = pixPromotion.effects?.parameters?.find(
@@ -22,11 +26,14 @@ export function calculatePixPromotion(offers: Offer[]): PixPromotionResult {
     );
 
     if (discountParam) {
-      discountPercentage = parseFloat(discountParam.value);
-      const originalPrice = offers?.[0]?.price || 0;
-      promotionalPrice = originalPrice * (1 - discountPercentage / 100);
+      const discount = parseFloat(discountParam.value);
+      promotionalPrice = Number(
+        (promotionalPrice * (1 - discount / 100)).toFixed(2),
+      );
     }
   }
 
-  return { promotionalPrice, discountPercentage };
+  return {
+    promotionalPrice: Number(promotionalPrice.toFixed(2)),
+  };
 }


### PR DESCRIPTION
# 12286 - Priorização do preço PIX em SEO e na PDP

## 🎯 Tipo de Mudança

  - [x] 🐛 **Correção de bug**
  - [x] ♻️ **Refatoração**

-----

## 📝 Descrição

  - Valores dos dados estruturados (JSON-LD) e meta tags ajustados para exibir o preço com desconto PIX/1x no cartão como principal.
  - Posicionamento do preço (`price`) e preço de lista (`listPrice`) ajustado na página de produto para correta hierarquia, com o preço principal sendo exibido primeiro no HTML.
  - Cálculo do valor PIX na página de produto refatorado para utilizar a mesma função (`calculatePixPromotion`) dos dados estruturados, garantindo consistência de valores.

-----

## 📸 Evidências Visuais

  - **Dados Estruturados:** [Antes](https://cln.sh/w8KK1BNC) | [Depois](https://cln.sh/qc1ZTRFX)
  - **Meta Tag Price:** [Antes](https://cln.sh/kZ1PcX6l) | [Depois](https://cln.sh/Wsv2SR0R)

-----

## ✅ Checklist de Qualidade

  - [x] Meu código segue as diretrizes deste projeto.
  - [x] Realizei uma revisão do meu próprio código.
  - [x] Testei o fluxo de navegação.
  - [x] Comentei meu código nas áreas de difícil compreensão.
  - [x] Minhas alterações não geram novos warnings.

-----

## 🔗 Referências

  - **Tarefa:** [#12286](https://runrun.it/pt-BR/tasks/12286)
  - **Design no Figma:** [link suspeito removido]