### PR TITLE
12286 - Ajustes no schema de produto para Google Merchant

### DIFF
--- a/sections/Seo/CustomProductSEO.tsx
+++ b/sections/Seo/CustomProductSEO.tsx
@@ -9,7 +9,7 @@ import {
 } from "$store/utils/yourViewsService.ts";
 import {
   buildAdditionalProperties,
-  extractAdditionalGTINs,
+  extractGTIN,
   extractProductCategories,
   extractProductSpecifications,
   extractProductWeight,
@@ -68,18 +68,22 @@ export async function loader(
 export default function CustomProductSEO(
   { page, reviewData, favicon }: SectionProps<typeof loader>,
 ): SEOSection {
-  if (!page?.product) return <div></div>;
+  if (!page?.product) return <div />;
   const product = page.product;
 
-  const fullProductName = product.isVariantOf?.name || product.name;
+  const fullProductName = product.isVariantOf?.name || product.name || "";
   const { category } = extractProductCategories(product);
   const specifications = extractProductSpecifications(product);
   const getSpecValue = (name: string) =>
     getSpecificationValue(specifications.specifications, name);
 
-  const originalPrice = getOfferPrice(
+  const listPrice = getOfferPrice(
     product.offers?.offers?.[0],
     "ListPrice",
+  );
+  const basePrice = getOfferPrice(
+    product.offers?.offers?.[0],
+    "SRP",
   );
   const { promotionalPrice } = calculatePixPromotion(
     product.offers?.offers,
@@ -97,7 +101,7 @@ export default function CustomProductSEO(
   const widthValue = parseWidthValue(widthStr);
   const weight = extractProductWeight(specifications.specifications);
 
-  const additionalGTINs = extractAdditionalGTINs(specifications.specifications);
+  const GTIN = extractGTIN(specifications);
   const additionalProperties = buildAdditionalProperties(
     specifications.specifications,
   );
@@ -105,7 +109,8 @@ export default function CustomProductSEO(
 
   const offers = buildOffersObject({
     product,
-    originalPrice,
+    basePrice,
+    listPrice,
     promotionalPrice,
     priceCurrency,
     availability,
@@ -116,10 +121,10 @@ export default function CustomProductSEO(
 
   const productData = buildProductData({
     product,
-    fullProductName: fullProductName || "",
+    fullProductName,
     category,
     specifications,
-    additionalGTINs,
+    GTIN,
     additionalProperties,
     weight,
     heightValue,

--- a/utils/seo/structuredDataBuilder.ts
+++ b/utils/seo/structuredDataBuilder.ts
@@ -29,7 +29,7 @@ export function buildPriceSpecifications(
     priceSpecifications.push({
       "@type": "UnitPriceSpecification",
       "priceType": "https://schema.org/StrikethroughPrice",
-      "price": listPrice,
+      "price": listPrice.toFixed(2),
       "priceCurrency": priceCurrency,
     });
   }
@@ -37,13 +37,13 @@ export function buildPriceSpecifications(
     {
       "@type": "UnitPriceSpecification",
       "priceType": "https://schema.org/RegularPrice",
-      "price": basePrice,
+      "price": basePrice.toFixed(2),
       "priceCurrency": priceCurrency,
     },
     {
       "@type": "UnitPriceSpecification",
       "priceType": "https://schema.org/SalePrice",
-      "price": offerPrice,
+      "price": offerPrice.toFixed(2),
       "priceCurrency": priceCurrency,
     },
   );
@@ -77,12 +77,12 @@ export function buildOffersObject(params: OfferBuilderParams) {
     return {
       "@type": "AggregateOffer",
       "priceCurrency": priceCurrency,
-      "lowPrice": promotionalPrice
-        ? Math.min(promotionalPrice, lowPrice)
-        : lowPrice,
-      "highPrice": promotionalPrice
-        ? Math.max(promotionalPrice, highPrice)
-        : highPrice,
+      "lowPrice":
+        (promotionalPrice ? Math.min(promotionalPrice, lowPrice) : lowPrice)
+          .toFixed(2),
+      "highPrice":
+        (promotionalPrice ? Math.max(promotionalPrice, highPrice) : highPrice)
+          .toFixed(2),
       "offerCount": product.offers?.offers?.length || 1,
       "availability": availability,
       "seller": {
@@ -91,7 +91,7 @@ export function buildOffersObject(params: OfferBuilderParams) {
       },
       "offers": product.offers?.offers?.map((offer) => ({
         "@type": "Offer",
-        "price": offer.price,
+        "price": offer.price?.toFixed(2),
         "priceCurrency": priceCurrency,
         "availability": offer.availability || availability,
         "seller": {
@@ -118,7 +118,7 @@ export function buildOffersObject(params: OfferBuilderParams) {
     return {
       "@type": "Offer",
       "priceCurrency": priceCurrency,
-      "price": price,
+      "price": price.toFixed(2),
       ...(priceValidUntil && listPrice !== basePrice &&
         { "priceValidUntil": priceValidUntil }),
       "availability": availability,


### PR DESCRIPTION
# 12286 - Ajustes no schema de produto para Google Merchant

## 🎯 Tipo de Mudança

  - [x] 🐛 **Correção de bug**
  - [x] ♻️ **Refatoração**

-----

## 📝 Descrição

Ajustes realizados no schema de dados estruturados do produto para melhorar a compatibilidade e a precisão das informações enviadas ao Google Merchant.

  - Lógica de extração de GTINs (`EAN`, `UPC`, etc.) refatorada para um sistema mais robusto que valida o tipo e a integridade do código.
  - Nomenclatura de preços alterada no `CustomProductSEO.tsx` de `originalPrice` para `listPrice` e `basePrice` para maior clareza.
  - Estrutura de `priceSpecification` nos dados estruturados modificada para utilizar `StrikethroughPrice` (preço "de"), `RegularPrice` (preço "por") e `SalePrice` (preço com desconto), refletindo melhor as diferentes condições de preço.
  - A função `buildOffersObject` foi atualizada para consumir `listPrice` e `basePrice`, garantindo que os dados de oferta agregada e individual estejam corretos.
  - Condição para exibição de `priceValidUntil` adicionada, mostrando o campo apenas quando há um preço promocional (`listPrice` é diferente de `basePrice`).

-----

## ✅ Checklist de Qualidade

  - [x] Meu código segue as diretrizes deste projeto.
  - [x] Realizei uma revisão do meu próprio código.
  - [x] Testei o fluxo de navegação.
  - [x] Comentei meu código nas áreas de difícil compreensão.
  - [x] Minhas alterações não geram novos warnings.

-----

## 🔗 Referências

  - **Tarefa:** [#12286](https://runrun.it/pt-BR/tasks/12286)